### PR TITLE
Fix typo in doc config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -228,7 +228,7 @@ man_pages = [
 texinfo_documents = [
     ('index', 'TriggerHappy', u'Trigger Happy Documentation',
      u'foxmask', 'TriggerHappy', 'take the control of your data with this'
-                                 'opensource clone of ITFFF',
+                                 'opensource clone of IFTTT',
      'Miscellaneous'),
 ]
 


### PR DESCRIPTION
Same typo appeared in https://trigger-happy.eu/  webpage , can't locate file to edit.  